### PR TITLE
Filtrer ut duplikate IP-adresser og skiller mellom IPv4 og IPv6

### DIFF
--- a/m365-single-tenant/Update-NamedLocationsFromHelseCert.ps1
+++ b/m365-single-tenant/Update-NamedLocationsFromHelseCert.ps1
@@ -16,9 +16,9 @@
     Scriptet anbefales kjørt en gang i timen.
 
 .NOTES
-    Version:        0.5
+    Version:        0.6
     Author:         SysIKT KO
-    Updated date:  2024-03-11
+    Updated date:  2025-11-06
 
     Takk til Alexander Filipin for utgangspunktet til scriptet:
     https://github.com/AlexFilipin/ConditionalAccess/blob/master/Deploy-NamedLocations.ps1

--- a/m365-single-tenant/Update-NamedLocationsFromHelseCert.ps1
+++ b/m365-single-tenant/Update-NamedLocationsFromHelseCert.ps1
@@ -17,7 +17,7 @@
 
 .NOTES
     Version:        0.6
-    Author:         SysIKT KO
+    Author:         Sopra Steria, SysIKT KO
     Updated date:  2025-11-06
 
     Takk til Alexander Filipin for utgangspunktet til scriptet:


### PR DESCRIPTION
Lagt til skille for IPv4 og IPv6 for å tilpasse formatet til Microsoft Graph, i tråd med dokumentasjonen her:
https://learn.microsoft.com/en-us/graph/api/resources/iprange?view=graph-rest-1.0

I tillegg er det nå lagt inn et filter som fjerner duplikater fra nedlastet IP-liste.